### PR TITLE
updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo dnf install pygtk2 pygame
 ```
 git clone https://github.com/sugarlabs/2-cars-activity.git
 cd 2-cars-activity
-python main.py
+python3 game.py
 ```
 
 **Running inside Sugar**


### PR DESCRIPTION
"python main.py" is changed to "python3 game.py". As the repo doesn't contain main.py. And python3 is valid syntax